### PR TITLE
Update init.rb / Redmine 5.x compatibility suggested fix.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,8 @@
 require 'redmine'
 
-require_dependency 'hooks/that_meeting_hook'
+Rails.configuration.to_prepare do
+  require_dependency 'that_meeting_hook'
+end
 
 Rails.logger.info 'Starting That Meeting plugin for Redmine'
 


### PR DESCRIPTION
Redmine 5.x compatibility suggested fix.  Not tested beyond ensuring that bundle install; bundle exec rake redmine:plugins:migrate RAILS_ENV=production; works.